### PR TITLE
Adjust method signatures to match parent

### DIFF
--- a/action.php
+++ b/action.php
@@ -29,7 +29,7 @@ class action_plugin_owncloud extends DokuWiki_Action_Plugin{
 	/**
 	 * Register all hooks
 	*/
-	function register(&$contr) {
+	function register(Doku_Event_Handler $contr) {
 		$contr->register_hook('IO_WIKIPAGE_WRITE','BEFORE',$this,'write');
 		//$contr->register_hook('PARSER_WIKITEXT_PREPROCESS','BEFORE',$this,'preprocess');
 		$contr->register_hook('MEDIA_UPLOAD_FINISH','AFTER',$this,'filecache',self::FILEUPDATE);

--- a/syntax.php
+++ b/syntax.php
@@ -52,7 +52,7 @@ class syntax_plugin_owncloud extends DokuWiki_Syntax_Plugin {
 		
 	}
 
-	function handle($match, $state, $pos, &$handler){
+	function handle($match, $state, $pos, Doku_Handler $handler){
 		$imagebox =false;
 		$rawdata = $match;
 		if(preg_match('#\[(.*)\]#',$match,$inside)){
@@ -66,7 +66,7 @@ class syntax_plugin_owncloud extends DokuWiki_Syntax_Plugin {
 		return array($match, $state, $pos);
 	}
 
-	function render($mode, &$renderer, $data){
+	function render($mode, Doku_Renderer $renderer, $data){
 		list($match, $state, $pos) = $data;
 		$helper = $this->loadHelper('owncloud',false);
 		if(!$helper) return false;


### PR DESCRIPTION
Starting with PHP 7, classes that overide methods from their parent have to match their parent's method signature regarding type hints. Otherwise PHP will throw an error.

Your plugin seems not to match DokuWiki's method signatures causing it to fail under PHP7. This patch tries to fix that.

Please note that this patch and the resulting pull request were created using an automated tool. Something might have gone, wrong so please carefully check before merging.

If you think the code submitted is wrong, please feel free to close this PR and excuse the mess.
